### PR TITLE
Favorite mutation

### DIFF
--- a/app/graphql/mutations/favorite_street_art.rb
+++ b/app/graphql/mutations/favorite_street_art.rb
@@ -1,0 +1,12 @@
+class Mutations::FavoriteStreetArt < Mutations::BaseMutation
+  argument :favorite, Boolean, required: true
+  argument :street_art_id, Integer, required: true
+
+  type Types::StreetArtType
+
+  def resolve(favorite: ,street_art_id:)
+    art = StreetArt.find(street_art_id)
+    art.update(favorite: favorite)
+    art.reload
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,5 +2,6 @@ module Types
   class MutationType < Types::BaseObject
     # TODO: remove me
     field :create_street_art, mutation: Mutations::CreateStreetArt
+    field :favorite_street_art, mutation: Mutations::FavoriteStreetArt
   end
 end

--- a/spec/requests/street_art_request_spec.rb
+++ b/spec/requests/street_art_request_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "art requests", type: :request do
     2.times do
       FactoryBot.create(:street_art, user: @user)
     end
+    @street_art = @user.street_arts[0]
   end
 
   after(:context) do
@@ -69,6 +70,17 @@ RSpec.describe "art requests", type: :request do
     response = JSON.parse(@response.body, symbolize_names: true)
 
     expect(response[:data][:createStreetArt][:id].to_i).to be_a(Integer)
+  end
+
+  it "favorites a street art post" do
+    expect(@street_art.favorite).to eq(false)
+
+    post "/graphql", params: { query: favorite_query(street_art_id: @street_art.id)}
+
+    response = JSON.parse(@response.body, symbolize_names: true)
+
+    expect(response[:data][:favoriteStreetArt][:id].to_i).to eq(@street_art.id)
+    expect(response[:data][:favoriteStreetArt][:favorite]).to eq(true)
   end
 
   def base_query(user_id:)
@@ -143,6 +155,20 @@ RSpec.describe "art requests", type: :request do
           imageUrls: "['url', 'url', 'url']"
         }) {
             id
+            }
+      }
+    GQL
+  end
+
+  def favorite_query(street_art_id:)
+    <<~GQL
+      mutation {
+        favoriteStreetArt( input: {
+          streetArtId: #{street_art_id}
+          favorite: true
+        }) {
+            id
+            favorite
             }
       }
     GQL


### PR DESCRIPTION
**Fixes issue #:** 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

**Description:**
- Add mutation to update the favorited attribute on a street art post

**What does this solve?:**
- Allows front end to toggle favorited or unfavorited for a post

**Notes:**
- This implementation will not work in production but will work for what we need in terms of the demo

- [X] All tests are passing
